### PR TITLE
fix issue with uninitialized member variable

### DIFF
--- a/src/LocoNetESP32.h
+++ b/src/LocoNetESP32.h
@@ -82,7 +82,7 @@ class LocoNetESP32: public LocoNetPhy
             VAL_RX_HIGH=HIGH
         };
 
-        bool _isrAttached;
+        bool _isrAttached = false;
         void IRAM_ATTR enableStartBitISR(bool en=true) ;
         void IRAM_ATTR loconetStartBit();
         void IRAM_ATTR loconetBitTimer();


### PR DESCRIPTION
sometimes LocoNetESP32 was not working, because member variable  _isrAttached was uninizialized and so possible != false at startup. Furtheron ISR was not correctly registered. 