### PR TITLE
Replace uint64_t with uint32_t to prevent arithmetic issues with micros()

### DIFF
--- a/src/LocoNet2.h
+++ b/src/LocoNet2.h
@@ -66,8 +66,9 @@
 #pragma once
 
 #include <map>
-
-// #include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
+#ifdef ARDUINO
+#include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
+#endif
 #include <etl/vector.h>
 #include <vector>
 #include <functional>
@@ -87,7 +88,7 @@
 // #include "LocoNetStream.h"
 
 // Uncomment the next line to enable library DEBUG Messages
-#define DEBUG_OUTPUT
+//#define DEBUG_OUTPUT
 
 #ifdef DEBUG_OUTPUT
     #include <cstdio>

--- a/src/LocoNetStream.cpp
+++ b/src/LocoNetStream.cpp
@@ -43,7 +43,7 @@ LN_STATUS LocoNetStream::sendLocoNetPacketTry (uint8_t *packetData, uint8_t pack
         {
             _serialPort->write (packetData, 1);
 
-            uint64_t startMillis = millis();
+            uint32_t startMillis = millis();
             int inByte = _serialPort->read();
             while (inByte == -1 and ( (millis() - startMillis) < 2))
                 inByte = _serialPort->read();

--- a/src/LocoNetStream.h
+++ b/src/LocoNetStream.h
@@ -66,9 +66,9 @@ private:
     bool hasCDBackoffTimerExpired (uint8_t PrioDelay = 0);
 
     Stream * 	_serialPort;
-    uint64_t 	_cdBackoffStart;
-    uint64_t 	_cdBackoffTimeout;
-    uint64_t 	_collisionTimeout;
+    uint32_t 	_cdBackoffStart;
+    uint32_t 	_cdBackoffTimeout;
+    uint32_t 	_collisionTimeout;
     LN_STATUS	_state;
 };
 


### PR DESCRIPTION
RX freezes when running for a a long time (overnight).  TX continues to work fine.

micros() returns unit32_t/(unsigned long). Assigning it to a uint64_t variable can cause issues with arithmetic, likely to happen when micros overflows every 70 minutes or so.  Key change is to LoconetStream.h:  
    uint32_t    _cdBackoffStart;
    uint32_t    _cdBackoffTimeout;
    uint32_t    _collisionTimeout;
