### PR TITLE
Fixed typo, OPC_GPON should be OPC_GPOFF

### DIFF
--- a/src/LocoNet2.cpp
+++ b/src/LocoNet2.cpp
@@ -413,7 +413,7 @@ void LocoNetDispatcher::onPowerChange (std::function<void (bool) > callback)
         DEBUG ("Power ON");
         callback (true);
     });
-    onPacket (OPC_GPON, [callback] (const LnMsg *packet)
+    onPacket (OPC_GPOFF, [callback] (const LnMsg *packet)
     {
         DEBUG ("Power OFF");
         callback (false);


### PR DESCRIPTION
Typo in LocoNetDispatcher::onPowerChange