### PR TITLE
implement stationary interrogate command

### DIFF
--- a/src/LocoNet2.cpp
+++ b/src/LocoNet2.cpp
@@ -298,6 +298,20 @@ LN_STATUS reportSensor (LocoNetBus *ln,  uint16_t Address, uint8_t State)
     return ln->broadcast (makeMsg (OPC_INPUT_REP, AddrL, AddrH));
 }
 
+void sendStationaryInterrogateCommand(LocoNetBus *ln, uint16_t baseAddress) {
+    requestSwitch(ln, baseAddress, 0, true);
+    requestSwitch(ln, baseAddress + 1, 0, true);
+    requestSwitch(ln, baseAddress + 2, 0, true);
+    requestSwitch(ln, baseAddress + 3, 0, true);
+    requestSwitch(ln, baseAddress, 0, false);
+    requestSwitch(ln, baseAddress + 1, 0, false);
+    requestSwitch(ln, baseAddress + 2, 0, false);
+    requestSwitch(ln, baseAddress + 3, 0, false);
+}
+void sendStationaryInterrogateCommand(LocoNetBus *ln) {
+    return sendStationaryInterrogateCommand(ln, 1017);
+}
+
 
 
 

--- a/src/LocoNet2.h
+++ b/src/LocoNet2.h
@@ -220,6 +220,9 @@ LN_STATUS reportSwitch (LocoNetBus *ln, uint16_t Address);
 LN_STATUS reportSensor (LocoNetBus *ln, uint16_t Address, uint8_t State);
 LN_STATUS reportPower (LocoNetBus *ln, bool state);
 
+void sendStationaryInterrogateCommand(LocoNetBus *ln, uint16_t baseAddress);
+void sendStationaryInterrogateCommand(LocoNetBus *ln);
+
 class LocoNetDispatcher : public LocoNetConsumer
 {
 public:


### PR DESCRIPTION
The stationary interrogate command (SIC) is an unofficial command that requests current switch states from every stationary decoder

if not configured, decoders by default respond with all their states if they receive a switch request to the addresses 1017-1020
the base address 1017 is defined in TrainController Gold Manual

even though it is kinda unofficial most LocoNot products do support it and respond accordingly