### PR TITLE
Make gcc check if Arduino etl header exists

### DIFF
--- a/src/Bus.h
+++ b/src/Bus.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-// #include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
 #include <etl/vector.h>
 
 #include "ln_opc.h"

--- a/src/LocoNet2.h
+++ b/src/LocoNet2.h
@@ -66,8 +66,8 @@
 #pragma once
 
 #include <map>
-#ifdef ARDUINO
-#include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
+#if defined(ARDUINO) && __has_include(<Embedded_Template_Library.h>)
+  #include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
 #endif
 #include <etl/vector.h>
 #include <vector>


### PR DESCRIPTION
Fixes builds in PlatformIO and in Github CI/CD. Hopefully does not break Arduino IDE builds.

Copy of https://github.com/mrrwa/LocoNet2/pull/21 with a different source branch (GH doesn't allow changing it)