### PR TITLE
Fix infinite RX loop on busy loconet bus and/or broken circuitry

### DIFF
--- a/src/Bus.h
+++ b/src/Bus.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-// #include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
 #include <etl/vector.h>
 
 #include "ln_opc.h"

--- a/src/LocoNet2.cpp
+++ b/src/LocoNet2.cpp
@@ -124,7 +124,7 @@ uint8_t writeChecksum (LnMsg &msg)
 LN_STATUS LocoNetPhy::send (LnMsg *pPacket, uint8_t ucPrioDelay)
 {
     LN_STATUS enReturn;
-    bool ucWaitForEnterBackoff;
+    bool seenBackoff;
 
     /* clip maximum prio delay */
     if (ucPrioDelay > LN_BACKOFF_MAX)
@@ -152,7 +152,8 @@ LN_STATUS LocoNetPhy::send (LnMsg *pPacket, uint8_t ucPrioDelay)
     {
         // wait previous traffic and than prio delay and than try tx
         // don't want to abort do/while loop before we did not see the backoff state once
-        ucWaitForEnterBackoff = true;
+        seenBackoff = false;
+
         do
         {
             //DEBUG("calling sendLocoNetPacketTry(%p, %d, %d) attempt %d", packet, packetLen, ucPrioDelay, ucTry);
@@ -169,20 +170,25 @@ LN_STATUS LocoNetPhy::send (LnMsg *pPacket, uint8_t ucPrioDelay)
             if (enReturn == LN_PRIO_BACKOFF)
             {
                 // now entered backoff -> next state != LN_BACKOFF is worth incrementing the try counter
-                ucWaitForEnterBackoff = false;
+                seenBackoff = true;
+            } else {
+                if(seenBackoff) {
+                    // first non-backoff result after a backoff ==> break loop and increment try
+                    break;
+                }
             }
-            //break;
         }
-        while ( (enReturn == LN_CD_BACKOFF) ||                              // waiting CD backoff
-                (enReturn == LN_COLLISION) ||                           	// waiting for the collision to expire
-                (enReturn == LN_PRIO_BACKOFF) ||                           // waiting master+prio backoff
-                ( (enReturn == LN_NETWORK_BUSY) && ucWaitForEnterBackoff)); // or within any traffic unfinished
+        while ( (enReturn == LN_CD_BACKOFF) ||                     // waiting CD backoff
+                (enReturn == LN_COLLISION) ||                      // waiting for the collision to expire
+                (enReturn == LN_PRIO_BACKOFF) ||                   // waiting master+prio backoff
+                ( (enReturn == LN_NETWORK_BUSY) && !seenBackoff)); // or within any traffic unfinished
         // failed -> next try going to higher prio = smaller prio delay
         if (ucPrioDelay > LN_BACKOFF_MIN)
         {
             ucPrioDelay--;
         }
     }
+
     txStats.txErrors++;
     return LN_RETRY_ERROR;
 }

--- a/src/LocoNet2.h
+++ b/src/LocoNet2.h
@@ -66,8 +66,8 @@
 #pragma once
 
 #include <map>
-#ifdef ARDUINO
-#include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
+#if defined(ARDUINO) && __has_include(<Embedded_Template_Library.h>)
+  #include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
 #endif
 #include <etl/vector.h>
 #include <vector>

--- a/src/LocoNetStream.cpp
+++ b/src/LocoNetStream.cpp
@@ -21,7 +21,7 @@ LN_STATUS LocoNetStream::sendLocoNetPacketTry (uint8_t *packetData, uint8_t pack
 
     else if (_state == LN_COLLISION && hasCollisionTimerExpired())
     {
-        _state = LN_CD_BACKOFF;
+        startCDBackoffTimer();
     }
 
     if (_state != LN_IDLE)
@@ -48,6 +48,11 @@ LN_STATUS LocoNetStream::sendLocoNetPacketTry (uint8_t *packetData, uint8_t pack
             while (inByte == -1 and ( (millis() - startMillis) < 2))
                 inByte = _serialPort->read();
 
+            if (inByte == -1) {
+                DEBUG ("sendLocoNetPacketTry: Did not receive echo");
+                // hardware problem in LocoNet transiever
+                return LN_UNKNOWN_ERROR;
+            }
             if (inByte != *packetData)
             {
                 DEBUG ("sendLocoNetPacketTry: Collision Detected  Tx: %0x  Rx: %0x", *packetData, inByte);
@@ -90,7 +95,6 @@ void LocoNetStream::process()
     {
         DEBUG ("process: Process LocoNet Bytes");
         while (_serialPort->available())
-// 			consume((uint8_t)_serialPort->read());
         {
             uint8_t inByte = _serialPort->read();
             DEBUG ("process: Byte: %02x", inByte);


### PR DESCRIPTION
For ESP32 code, 2 bugs fixed:

* backoff timer did not start after collision timer expired (it was only started after successful transmit/receive)
* lack of UART echo (`read` returns -1) was treated as LN_COLLISION (now LN_UNKNOWN_ERROR)

These bugs caused sending loop in sendLocoNetPacketTry to remain in inner (infinite) loop forever instead of incrementing attempt counter and limiting attempts in cases when LocoNet bus was constantly busy or unconnected. Infinite loop caused whole program to freeze and eventually reset due to ESP32 watchdog.