### PR TITLE
remove ETL library dependency

### DIFF
--- a/lib/Embedded_Template_Library.h
+++ b/lib/Embedded_Template_Library.h
@@ -1,8 +1,0 @@
-#pragma once
-
-// Compatibility wrapper for PlatformIO builds
-// This header satisfies the `#include <Embedded_Template_Library.h>` directive
-// used in Arduino IDE. The actual ETL functionality comes from <etl/vector.h>
-// and related headers already included separately.
-//
-// This file can be empty because the real ETL headers are included via <etl/vector.h>

--- a/library.json
+++ b/library.json
@@ -27,9 +27,6 @@
     "license": "GPL-2.0-or-later",
     "frameworks": "arduino",
     "platforms": "espressif32",
-    "dependencies": {
-    	"etlcpp/Embedded Template Library - Arduino": "^20.38.2"
-    },
     "build": {
         "srcFilter" : [
             "-<.git/>",

--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,5 @@ sentence=Enables Digitrax LocoNet Communication
 paragraph=This library allows you to interface to a LocoNet network and send/receive LocoNet commands. The library currently supports the ESP32
 category=Communication
 url=http://mrrwa.org/loconet-interface/
-depends=Embedded Template Library ETL (>=20.22.0)
 architectures=esp32,rp2040,stm32
 dot_a_linkage=true

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,6 @@ board = esp32dev
 framework = arduino
 lib_deps= 
     EEPROM
-    ETLCPP/Embedded Template Library
 build_flags = -DDEBUG_OUTPUT=true
 
 [env:test]
@@ -23,5 +22,4 @@ board = esp32dev
 framework = arduino
 lib_deps =
     ThrowTheSwitch/Unity
-    ETLCPP/Embedded Template Library
 build_flags = -DDEBUG_OUTPUT=true -DUNITY_INCLUDE_CONFIG_H

--- a/src/Bus.h
+++ b/src/Bus.h
@@ -6,25 +6,7 @@
 
 #pragma once
 
-#if defined(ARDUINO) && !defined(PLATFORMIO)
-  // The <Embedded_Template_Library.h> try to redefine ARDUINO_BOARD
-  // so the preprocessor code below should suppress the warning 
-  //
-  // Save the compiler-injected board name to restore later
-  #ifdef ARDUINO_BOARD
-    #define ORIGINAL_ARDUINO_BOARD ARDUINO_BOARD
-    #undef ARDUINO_BOARD
-  #endif
-
-  #include <Embedded_Template_Library.h> // Mandatory for Arduino IDE only
-  
-  // Restore the original board definition
-  #ifdef ORIGINAL_ARDUINO_BOARD
-    #undef ARDUINO_BOARD
-    #define ARDUINO_BOARD ORIGINAL_ARDUINO_BOARD
-  #endif  
-#endif
-#include <etl/vector.h>
+#include <vector>
 
 #include "ln_opc.h"
 
@@ -72,12 +54,12 @@ public:
         consumers.push_back (c);
     }
 
-    void removeConsumer (MsgConsumer * c)
-    {
-        consumers.erase (etl::remove (consumers.begin(), consumers.end(), c), consumers.end());
+    void removeConsumer(MsgConsumer * c) {
+        consumers.erase( std::remove(consumers.begin(), consumers.end(), c), consumers.end() );
     }
 
 private:
-    etl::vector<MsgConsumer*, MAX_CONSUMERS> consumers;
+    //std::vector<MsgConsumer*, MAX_CONSUMERS> consumers;
+    std::vector<MsgConsumer*> consumers;
 };
 

--- a/src/LocoNet2.h
+++ b/src/LocoNet2.h
@@ -66,30 +66,8 @@
 #pragma once
 
 #include <map>
-#if defined(ARDUINO) && !defined(PLATFORMIO)
-  // The <Embedded_Template_Library.h> try to redefine ARDUINO_BOARD
-  // so the preprocessor code below should suppress the warning 
-  //
-  // Save the compiler-injected board name to restore later
-  #ifdef ARDUINO_BOARD
-    #define ORIGINAL_ARDUINO_BOARD ARDUINO_BOARD
-    #undef ARDUINO_BOARD
-  #endif
-
-  #include <Embedded_Template_Library.h>
-
-    // Restore the original board definition
-  #ifdef ORIGINAL_ARDUINO_BOARD
-    #undef ARDUINO_BOARD
-    #define ARDUINO_BOARD ORIGINAL_ARDUINO_BOARD
-  #endif  
-  
-#endif
-
-#include <etl/vector.h>
-
+#include <vector>
 #include <functional>
-#include <vector>  // This is needed for PlatformIO to build
 
 #include "ln_opc.h"
 #include "LocoNetMessageBuffer.h"


### PR DESCRIPTION
I had troubles compiling with ETL on PlatformIO (even after the commits last week).

After checking, I noticed only the vector is from ETL and nothing else.
When compiling for ESP32, the compiler includes the std vector which can be used instead.

As far as I know this library is only intended for ESP32?

You need to check if this works on Arduino IDE and other architectures as well.

I've been using this library like this for many weeks now.

This would also fix #27 (ci runs through without issues on my repo)
